### PR TITLE
[application] 모든 원서 조회 기능 구현

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
@@ -3,12 +3,12 @@ package team.themoment.hellogsmv3.domain.application.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import team.themoment.hellogsmv3.domain.application.dto.response.ApplicationListResDto;
 import team.themoment.hellogsmv3.domain.application.dto.response.FoundApplicationResDto;
+import team.themoment.hellogsmv3.domain.application.service.QueryAllApplicationService;
 import team.themoment.hellogsmv3.domain.application.service.QueryApplicationByIdService;
+import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.security.auth.AuthenticatedUserManager;
 
 @RestController
@@ -18,6 +18,7 @@ public class ApplicationController {
 
     private final AuthenticatedUserManager manager;
     private final QueryApplicationByIdService queryApplicationByIdService;
+    private final QueryAllApplicationService queryAllApplicationService;
 
     @GetMapping("/application/me")
     public ResponseEntity<FoundApplicationResDto> findMe() {
@@ -29,5 +30,16 @@ public class ApplicationController {
     public ResponseEntity<FoundApplicationResDto> findOne(@PathVariable("authenticationId") Long userId) {
         FoundApplicationResDto foundApplicationResDto = queryApplicationByIdService.execute(userId);
         return ResponseEntity.status(HttpStatus.OK).body(foundApplicationResDto);
+    }
+
+    @GetMapping("/application/all")
+    public ResponseEntity<ApplicationListResDto> findAll(
+            @RequestParam("page") Integer page,
+            @RequestParam("size") Integer size
+    ) {
+        if (page < 0 || size < 0)
+            throw new ExpectedException("page, size는 0 이상만 가능합니다", HttpStatus.BAD_REQUEST);
+        ApplicationListResDto applicationListResDto = queryAllApplicationService.execute(page, size);
+        return ResponseEntity.status(HttpStatus.OK).body(applicationListResDto);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/ApplicationDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/ApplicationDto.java
@@ -1,0 +1,29 @@
+package team.themoment.hellogsmv3.domain.application.dto.response;
+
+import lombok.Builder;
+import team.themoment.hellogsmv3.domain.application.type.EvaluationStatus;
+import team.themoment.hellogsmv3.domain.application.type.GraduationStatus;
+import team.themoment.hellogsmv3.domain.application.type.Screening;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Builder
+public record ApplicationDto(
+        UUID applicationId,
+        String applicantName,
+        GraduationStatus graduation,
+        String applicantPhoneNumber,
+        String guardianPhoneNumber,
+        String teacherName,
+        String teacherPhoneNumber,
+        Boolean isFinalSubmitted,
+        Boolean isPrintsArrived,
+        EvaluationStatus firstEvaluation,
+        EvaluationStatus secondEvaluation,
+        Screening screeningFirstEvaluationAt,
+        Screening screeningSecondEvaluationAt,
+        Long registrationNumber,
+        BigDecimal secondScore
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/ApplicationListInfoDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/ApplicationListInfoDto.java
@@ -1,0 +1,7 @@
+package team.themoment.hellogsmv3.domain.application.dto.response;
+
+public record ApplicationListInfoDto (
+        Integer totalPages,
+        Long totalElements
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/ApplicationListResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/ApplicationListResDto.java
@@ -1,0 +1,9 @@
+package team.themoment.hellogsmv3.domain.application.dto.response;
+
+import java.util.List;
+
+public record ApplicationListResDto(
+        ApplicationListInfoDto paginationInfo,
+        List<ApplicationDto> applications
+) {
+}

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryAllApplicationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryAllApplicationService.java
@@ -1,0 +1,69 @@
+package team.themoment.hellogsmv3.domain.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsmv3.domain.applicant.entity.Applicant;
+import team.themoment.hellogsmv3.domain.application.dto.response.ApplicationDto;
+import team.themoment.hellogsmv3.domain.application.dto.response.ApplicationListInfoDto;
+import team.themoment.hellogsmv3.domain.application.dto.response.ApplicationListResDto;
+import team.themoment.hellogsmv3.domain.application.entity.CandidatePersonalInformation;
+import team.themoment.hellogsmv3.domain.application.entity.abs.AbstractApplication;
+import team.themoment.hellogsmv3.domain.application.entity.abs.AbstractPersonalInformation;
+import team.themoment.hellogsmv3.domain.application.repo.ApplicationRepository;
+import team.themoment.hellogsmv3.domain.application.type.GraduationStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QueryAllApplicationService {
+
+    private final ApplicationRepository applicationRepository;
+
+    public ApplicationListResDto execute(Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<AbstractApplication> applicationPage = applicationRepository.findAll(pageable);
+        ApplicationListInfoDto paginationInfo = new ApplicationListInfoDto(applicationPage.getTotalPages(), applicationPage.getTotalElements());
+        List<AbstractApplication> applicationList = applicationPage.toList();
+        List<ApplicationDto> applicationDtoList = new ArrayList<ApplicationDto>(applicationList.size());
+
+        for ( AbstractApplication application : applicationList ) {
+            Applicant applicant = application.getApplicant();
+
+            AbstractPersonalInformation personalInformation = application.getPersonalInformation();
+            CandidatePersonalInformation generalPersonalInformation = null;
+            boolean isGed = application.getPersonalInformation().getGraduation() == GraduationStatus.GED;
+            if (!isGed) {
+                generalPersonalInformation = (CandidatePersonalInformation) Hibernate.unproxy(personalInformation);
+            }
+
+            applicationDtoList.add(ApplicationDto.builder()
+                            .applicationId(application.getId())
+                            .applicantName(applicant.getName())
+                            .graduation(personalInformation.getGraduation())
+                            .applicantPhoneNumber(personalInformation.getPhoneNumber())
+                            .guardianPhoneNumber(personalInformation.getGuardianPhoneNumber())
+                            .teacherName(isGed ? null : generalPersonalInformation.getTeacherName())
+                            .teacherPhoneNumber(isGed ? null : generalPersonalInformation.getTeacherPhoneNumber())
+                            .isFinalSubmitted(application.getFinalSubmitted())
+                            .isPrintsArrived(application.getPrintsArrived())
+                            .firstEvaluation(application.getSubjectEvaluationResult().getEvaluationStatus())
+                            .secondEvaluation(application.getCompetencyEvaluationResult().getEvaluationStatus())
+                            .screeningFirstEvaluationAt(application.getSubjectEvaluationResult() != null ? application.getSubjectEvaluationResult().getPostScreeningEvaluation() : null)
+                            .screeningSecondEvaluationAt(application.getCompetencyEvaluationResult() != null ? application.getCompetencyEvaluationResult().getPostScreeningEvaluation() : null)
+                            .registrationNumber(application.getRegistrationNumber())
+                            .secondScore(application.getCompetencyExamScore())
+                            .build());
+        }
+
+        return new ApplicationListResDto(
+                paginationInfo,
+                applicationDtoList
+        );
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -153,6 +153,9 @@ public class SecurityConfig {
                         Role.ADMIN.name(),
                         Role.ROOT.name()
                 )
+                .requestMatchers(HttpMethod.GET, "/application/v3/application/all").hasAnyAuthority(
+                        Role.ADMIN.name()
+                )
                 .requestMatchers(HttpMethod.GET, "/application/v3/application/{authenticationId}").hasAnyAuthority(
                         Role.ADMIN.name()
                 )


### PR DESCRIPTION
## 개요

모든 원서(application)을 조회하는 기능을 구현하였습니다.

## 본문

`/application/v3/application/all`로 요청하여 관리자(선생님)가 모든 원서를 조회할 수 있습니다.

### 기타

현재 N+1 문제도 발생하고 지연로딩이라 `Hibernate.unproxy()`로 직접 원본 객체를 가져오고 있습니다.
이는 fetchJoin을 사용하여 해결하면 될 것 같습니다. 일단 기능 자체는 구현 되었기에 다른 부분 리뷰받으려고 pr올립니다.
