### PR TITLE
[applicant] 인증번호 로직에서 사용되는 AuthenticationCode 엔티티 개선

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/AuthenticationCode.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/AuthenticationCode.java
@@ -24,12 +24,12 @@ public class AuthenticationCode {
     private Boolean authenticated;
     private String phoneNumber;
     private LocalDateTime createdAt;
-    private int count = 1;
+    private int count;
 
     public AuthenticationCode updatedCode(String code, LocalDateTime createdAt, Boolean isTest) {
         this.code = code;
         this.createdAt = createdAt;
-        this.count = !isTest ? (count + 1) : 0;
+        this.count = !isTest ? (count + 1) : 0; // 테스트 상황이라면 count가 증가하지 않음
         return this;
     }
 
@@ -39,6 +39,7 @@ public class AuthenticationCode {
         this.authenticated = false;
         this.phoneNumber = phoneNumber;
         this.createdAt = createdAt;
+        this.count = 1;
     }
 
     public void authenticatedAuthenticationCode() {

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/AuthenticationCode.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/AuthenticationCode.java
@@ -26,16 +26,10 @@ public class AuthenticationCode {
     private LocalDateTime createdAt;
     private int count = 1;
 
-    public AuthenticationCode updatedCode(String code, LocalDateTime createdAt) {
+    public AuthenticationCode updatedCode(String code, LocalDateTime createdAt, Boolean isTest) {
         this.code = code;
         this.createdAt = createdAt;
-        this.count++;
-        return this;
-    }
-
-    public AuthenticationCode updatedTestCode(String code, LocalDateTime createdAt) {
-        this.code = code;
-        this.createdAt = createdAt;
+        this.count = !isTest ? (count + 1) : 0;
         return this;
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/AuthenticationCode.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/AuthenticationCode.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
 import java.time.LocalDateTime;
@@ -16,10 +17,37 @@ import java.time.LocalDateTime;
 @RedisHash(timeToLive = 3600L)
 public class AuthenticationCode {
     @Id
-    private String code;
     @Indexed
     private Long authenticationId;
+    @Indexed
+    private String code;
     private Boolean authenticated;
     private String phoneNumber;
     private LocalDateTime createdAt;
+    private int count = 1;
+
+    public AuthenticationCode updatedCode(String code, LocalDateTime createdAt) {
+        this.code = code;
+        this.createdAt = createdAt;
+        this.count++;
+        return this;
+    }
+
+    public AuthenticationCode updatedTestCode(String code, LocalDateTime createdAt) {
+        this.code = code;
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public AuthenticationCode(Long authenticationId, String code, String phoneNumber, LocalDateTime createdAt) {
+        this.authenticationId = authenticationId;
+        this.code = code;
+        this.authenticated = false;
+        this.phoneNumber = phoneNumber;
+        this.createdAt = createdAt;
+    }
+
+    public void authenticatedAuthenticationCode() {
+        this.authenticated = true;
+    }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/AuthenticationCode.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/entity/AuthenticationCode.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @RedisHash(timeToLive = 3600L)
 public class AuthenticationCode {
     @Id

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/repo/CodeRepository.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/repo/CodeRepository.java
@@ -4,8 +4,9 @@ import org.springframework.data.repository.CrudRepository;
 import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CodeRepository extends CrudRepository<AuthenticationCode, String> {
-
-    List<AuthenticationCode> findByAuthenticationId(Long authenticationId);
+    Optional<AuthenticationCode> findByAuthenticationId(Long authenticationId);
+    Optional<AuthenticationCode> findByCode(String code);
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/AuthenticateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/AuthenticateCodeService.java
@@ -20,23 +20,15 @@ public class AuthenticateCodeService {
     private final CodeRepository codeRepository;
 
     public void execute(Long userId, AuthenticateCodeReqDto reqDto) {
-        List<AuthenticationCode> codes = codeRepository.findByAuthenticationId(userId);
 
-        AuthenticationCode recentCode = codes.stream()
-                .max(Comparator.comparing(AuthenticationCode::getCreatedAt))
+        AuthenticationCode code = codeRepository.findByAuthenticationId(userId)
                 .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 ID : " + userId, HttpStatus.BAD_REQUEST));
 
-        if (!recentCode.getCode().equals(reqDto.code()))
+        if (!code.getCode().equals(reqDto.code()))
             throw new ExpectedException("유효하지 않은 code 입니다. 이전 혹은 잘못된 code입니다.", HttpStatus.BAD_REQUEST);
 
-        AuthenticationCode updatedAuthenticationCode = new AuthenticationCode(
-                recentCode.getCode(),
-                recentCode.getAuthenticationId(),
-                true,
-                recentCode.getPhoneNumber(),
-                recentCode.getCreatedAt()
-        );
+        code.authenticatedAuthenticationCode();
 
-        codeRepository.save(updatedAuthenticationCode);
+        codeRepository.save(code);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CommonCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CommonCodeService.java
@@ -16,28 +16,26 @@ public class CommonCodeService {
 
     private final CodeRepository codeRepository;
 
-    public List<AuthenticationCode> validateAndGetRecentCode(Long authenticationId, String inputCode, String inputPhoneNumber) {
-        List<AuthenticationCode> codes = codeRepository.findByAuthenticationId(authenticationId);
-        AuthenticationCode recentCode = codes.stream()
-                .max(Comparator.comparing(AuthenticationCode::getCreatedAt))
+    public AuthenticationCode validateAndGetRecentCode(Long authenticationId, String inputCode, String inputPhoneNumber) {
+        AuthenticationCode code = codeRepository.findByAuthenticationId(authenticationId)
                 .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 ID : " + authenticationId, HttpStatus.BAD_REQUEST));
 
-        if (!recentCode.getAuthenticated()) {
+        if (!code.getAuthenticated()) {
             throw new ExpectedException("유효하지 않은 요청입니다. 인증받지 않은 code입니다.", HttpStatus.BAD_REQUEST);
         }
 
-        if (!recentCode.getCode().equals(inputCode)) {
+        if (!code.getCode().equals(inputCode)) {
             throw new ExpectedException("유효하지 않은 요청입니다. 이전 혹은 잘못된 형식의 code입니다.", HttpStatus.BAD_REQUEST);
         }
 
-        if (!recentCode.getPhoneNumber().equals(inputPhoneNumber)) {
+        if (!code.getPhoneNumber().equals(inputPhoneNumber)) {
             throw new ExpectedException("유효하지 않은 요청입니다. code인증에 사용되었던 전화번호와 요청에 사용한 전화번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
         }
 
-        return codes;
+        return code;
     }
 
-    public void deleteCodes(List<AuthenticationCode> codes) {
-        codes.forEach(code -> codeRepository.deleteById(code.getCode()));
+    public void deleteCode(AuthenticationCode code) {
+        codeRepository.delete(code);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
@@ -32,7 +32,7 @@ public class CreateApplicantService {
         if (applicantRepository.existsByAuthenticationId(authenticationId))
             throw new ExpectedException("이미 존재하는 Applicant 입니다", HttpStatus.BAD_REQUEST);
 
-        List<AuthenticationCode> codes = commonCodeService.validateAndGetRecentCode(authenticationId, reqDto.code(), reqDto.phoneNumber());
+        AuthenticationCode code = commonCodeService.validateAndGetRecentCode(authenticationId, reqDto.code(), reqDto.phoneNumber());
 
         Authentication roleUpdatedAuthentication = authenticationRepository.save(
                 new Authentication(
@@ -52,7 +52,7 @@ public class CreateApplicantService {
         );
         applicantRepository.save(newApplicant);
 
-        commonCodeService.deleteCodes(codes);
+        commonCodeService.deleteCode(x);
 
         return roleUpdatedAuthentication.getRole();
     };

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/CreateApplicantService.java
@@ -52,7 +52,7 @@ public class CreateApplicantService {
         );
         applicantRepository.save(newApplicant);
 
-        commonCodeService.deleteCode(x);
+        commonCodeService.deleteCode(code);
 
         return roleUpdatedAuthentication.getRole();
     };

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateCodeService.java
@@ -18,11 +18,12 @@ public abstract class GenerateCodeService {
             AuthenticationCode authCode,
             Long authenticationId,
             String code,
-            String phoneNumber) {
+            String phoneNumber,
+            boolean isTest) {
 
         return authCode == null ?
                 new AuthenticationCode(authenticationId, code, phoneNumber, LocalDateTime.now()) :
-                authCode.updatedCode(code, LocalDateTime.now());
+                authCode.updatedCode(code, LocalDateTime.now(), isTest);
     }
 
     protected String generateUniqueCode(Random RANDOM, CodeRepository codeRepository) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateCodeService.java
@@ -1,8 +1,10 @@
 package team.themoment.hellogsmv3.domain.applicant.service;
 
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsmv3.domain.applicant.entity.AuthenticationCode;
 import team.themoment.hellogsmv3.domain.applicant.repo.CodeRepository;
 
+import java.time.LocalDateTime;
 import java.util.Random;
 
 public abstract class GenerateCodeService {
@@ -11,6 +13,17 @@ public abstract class GenerateCodeService {
     protected final static int MAX = (int) Math.pow(10, DIGIT_NUMBER) - 1;
 
     protected abstract String execute(Long userId, GenerateCodeReqDto reqDto);
+
+    protected AuthenticationCode createAuthenticationCode(
+            AuthenticationCode authCode,
+            Long authenticationId,
+            String code,
+            String phoneNumber) {
+
+        return authCode == null ?
+                new AuthenticationCode(authenticationId, code, phoneNumber, LocalDateTime.now()) :
+                authCode.updatedCode(code, LocalDateTime.now());
+    }
 
     protected String generateUniqueCode(Random RANDOM, CodeRepository codeRepository) {
         String code;

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateCodeService.java
@@ -21,7 +21,7 @@ public abstract class GenerateCodeService {
     }
 
     protected Boolean isDuplicate(String code, CodeRepository codeRepository) {
-        return codeRepository.findById(code).isPresent();
+        return codeRepository.findByCode(code).isPresent();
     }
 
     protected String getRandomCode(Random RANDOM) {

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateCodeService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/GenerateCodeService.java
@@ -8,9 +8,9 @@ import java.time.LocalDateTime;
 import java.util.Random;
 
 public abstract class GenerateCodeService {
-    protected final static int DIGIT_NUMBER = 6;
-    protected final static int LIMIT_COUNT_CODE_REQUEST = 5;
-    protected final static int MAX = (int) Math.pow(10, DIGIT_NUMBER) - 1;
+    protected static final int DIGIT_NUMBER = 6;
+    protected static final int LIMIT_COUNT_CODE_REQUEST = 5;
+    protected static final int MAX = (int) Math.pow(10, DIGIT_NUMBER) - 1;
 
     protected abstract String execute(Long authenticationId, GenerateCodeReqDto reqDto);
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/ModifyApplicantService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/ModifyApplicantService.java
@@ -29,7 +29,7 @@ public class ModifyApplicantService {
         Applicant savedApplicant = applicantRepository.findByAuthenticationId(authenticationId)
                 .orElseThrow(() -> new ExpectedException("존재하지 않는 Applicant 입니다", HttpStatus.BAD_REQUEST));
 
-        List<AuthenticationCode> codes = commonCodeService.validateAndGetRecentCode(authenticationId, reqDto.code(), reqDto.phoneNumber());
+        AuthenticationCode code = commonCodeService.validateAndGetRecentCode(authenticationId, reqDto.code(), reqDto.phoneNumber());
 
         Applicant newApplicant = new Applicant(
                 savedApplicant.getId(),
@@ -41,6 +41,6 @@ public class ModifyApplicantService {
         );
         applicantRepository.save(newApplicant);
 
-        commonCodeService.deleteCodes(codes);
+        commonCodeService.deleteCode(code);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateCodeServiceImpl.java
@@ -39,7 +39,7 @@ public class GenerateCodeServiceImpl extends GenerateCodeService {
                 reqDto.phoneNumber(),
                 false));
 
-        // 문자 발송 로직
+        // TODO 문자 발송 로직
 
         return code;
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateCodeServiceImpl.java
@@ -17,26 +17,33 @@ import java.util.Random;
 public class GenerateCodeServiceImpl extends GenerateCodeService {
 
     private final CodeRepository codeRepository;
-    private final static Random RANDOM = new Random();
+    private static final Random RANDOM = new Random();
 
     @Override
-    public String execute(Long userId, GenerateCodeReqDto reqDto) {
+    public String execute(Long authenticationId, GenerateCodeReqDto reqDto) {
 
-        if (isLimitedRequest(userId))
+        AuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
+                .orElse(null);
+
+        if (isLimitedRequest(authenticationCode))
             throw new ExpectedException(String.format(
                     "너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요. 특정 시간 내 제한 횟수인 %d회를 초과하였습니다.",
                     LIMIT_COUNT_CODE_REQUEST), HttpStatus.FORBIDDEN);
 
         final String code = generateUniqueCode(RANDOM, codeRepository);
-        codeRepository.save(new AuthenticationCode(code, userId, false, reqDto.phoneNumber(), LocalDateTime.now()));
+
+        codeRepository.save(
+                authenticationCode == null ?
+                    new AuthenticationCode(authenticationId, code, reqDto.phoneNumber(), LocalDateTime.now()) :
+                    authenticationCode.updatedCode(code, LocalDateTime.now())
+                );
 
         // 문자 발송 로직
 
         return code;
     }
 
-    private Boolean isLimitedRequest(Long userId) {
-        long count = codeRepository.findByAuthenticationId(userId).stream().count();
-        return count >= LIMIT_COUNT_CODE_REQUEST;
+    private boolean isLimitedRequest(AuthenticationCode authenticationCode) {
+        return authenticationCode != null && authenticationCode.getCount() >= LIMIT_COUNT_CODE_REQUEST;
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateCodeServiceImpl.java
@@ -32,11 +32,7 @@ public class GenerateCodeServiceImpl extends GenerateCodeService {
 
         final String code = generateUniqueCode(RANDOM, codeRepository);
 
-        codeRepository.save(
-                authenticationCode == null ?
-                    new AuthenticationCode(authenticationId, code, reqDto.phoneNumber(), LocalDateTime.now()) :
-                    authenticationCode.updatedCode(code, LocalDateTime.now())
-                );
+        codeRepository.save(createAuthenticationCode(authenticationCode, authenticationId, code, reqDto.phoneNumber()));
 
         // 문자 발송 로직
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateCodeServiceImpl.java
@@ -32,7 +32,12 @@ public class GenerateCodeServiceImpl extends GenerateCodeService {
 
         final String code = generateUniqueCode(RANDOM, codeRepository);
 
-        codeRepository.save(createAuthenticationCode(authenticationCode, authenticationId, code, reqDto.phoneNumber()));
+        codeRepository.save(createAuthenticationCode(
+                authenticationCode,
+                authenticationId,
+                code,
+                reqDto.phoneNumber(),
+                false));
 
         // 문자 발송 로직
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateTestCodeServiceImpl.java
@@ -24,11 +24,7 @@ public class GenerateTestCodeServiceImpl extends GenerateCodeService {
         AuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
                 .orElse(null);
 
-        codeRepository.save(
-                authenticationCode == null ?
-                        new AuthenticationCode(authenticationId, code, reqDto.phoneNumber(), LocalDateTime.now()) :
-                        authenticationCode.updatedTestCode(code, LocalDateTime.now())
-        );
+        codeRepository.save(createAuthenticationCode(authenticationCode, authenticationId, code, reqDto.phoneNumber()));
 
         return code;
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateTestCodeServiceImpl.java
@@ -15,12 +15,21 @@ import java.util.Random;
 public class GenerateTestCodeServiceImpl extends GenerateCodeService {
 
     private final CodeRepository codeRepository;
-    private final static Random RANDOM = new Random();
+    private static final Random RANDOM = new Random();
 
     @Override
-    public String execute(Long userId, GenerateCodeReqDto reqDto) {
+    public String execute(Long authenticationId, GenerateCodeReqDto reqDto) {
         final String code = generateUniqueCode(RANDOM, codeRepository);
-        codeRepository.save(new AuthenticationCode(code, userId, false, reqDto.phoneNumber(), LocalDateTime.now()));
+
+        AuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
+                .orElse(null);
+
+        codeRepository.save(
+                authenticationCode == null ?
+                        new AuthenticationCode(authenticationId, code, reqDto.phoneNumber(), LocalDateTime.now()) :
+                        authenticationCode.updatedTestCode(code, LocalDateTime.now())
+        );
+
         return code;
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateTestCodeServiceImpl.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/service/impl/GenerateTestCodeServiceImpl.java
@@ -24,7 +24,12 @@ public class GenerateTestCodeServiceImpl extends GenerateCodeService {
         AuthenticationCode authenticationCode = codeRepository.findByAuthenticationId(authenticationId)
                 .orElse(null);
 
-        codeRepository.save(createAuthenticationCode(authenticationCode, authenticationId, code, reqDto.phoneNumber()));
+        codeRepository.save(createAuthenticationCode(
+                authenticationCode,
+                authenticationId,
+                code,
+                reqDto.phoneNumber(),
+                true));
 
         return code;
     }


### PR DESCRIPTION
## 개요

#24 인증번호 발송 로직을 개선하였습니다.

## 본문 

인증번호 로직에서 인증번호 객체를 여러번 저장하여 객체의 갯수로 최대 발송 갯수를 제한하는 방식에서, count 컬럼을 추가하여 해당 컬럼으로 최대 발송 갯수를 제한하는 방식으로 변경하였습니다.