### PR TITLE
[global] response 공통화 작업

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
@@ -64,7 +64,7 @@ public class ApplicantController {
     ) {
         Role role = createApplicantService.execute(reqDto, manager.getId());
         manager.setRole(httpServletRequest, role);
-        return CommonApiResponse.created("본인인증이 완료되었습니다");
+        return CommonApiResponse.created("본인인증이 완료되었습니다.");
     }
 
     @PutMapping("/applicant/me")
@@ -72,20 +72,18 @@ public class ApplicantController {
             @RequestBody @Valid ApplicantReqDto reqDto
     ) {
         modifyApplicantService.execute(reqDto, manager.getId());
-        return CommonApiResponse.success("수정되었습니다");
+        return CommonApiResponse.success("수정되었습니다.");
     }
 
     @GetMapping("/applicant/me")
     public FoundApplicantResDto find() {
-        FoundApplicantResDto foundApplicantResDto = queryApplicantByIdService.execute(manager.getId());
-        return foundApplicantResDto;
+        return queryApplicantByIdService.execute(manager.getId());
     }
 
     @GetMapping("/applicant/{authenticationId}")
     public FoundApplicantResDto findByUserId(
             @PathVariable Long authenticationId
     ) {
-        FoundApplicantResDto foundApplicantResDto = queryApplicantByIdService.execute(authenticationId);
-        return foundApplicantResDto;
+        return queryApplicantByIdService.execute(authenticationId);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
@@ -3,8 +3,6 @@ package team.themoment.hellogsmv3.domain.applicant.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.ApplicantReqDto;
 import team.themoment.hellogsmv3.domain.applicant.dto.response.FoundApplicantResDto;
@@ -17,7 +15,7 @@ import team.themoment.hellogsmv3.domain.applicant.service.ModifyApplicantService
 import team.themoment.hellogsmv3.domain.applicant.service.impl.GenerateCodeServiceImpl;
 import team.themoment.hellogsmv3.domain.applicant.service.impl.GenerateTestCodeServiceImpl;
 import team.themoment.hellogsmv3.domain.auth.type.Role;
-import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiMessageResponse;
 import team.themoment.hellogsmv3.global.security.auth.AuthenticatedUserManager;
 
 @RestController
@@ -34,45 +32,45 @@ public class ApplicantController {
     private final GenerateCodeServiceImpl generateCodeService;
 
     @PostMapping("/applicant/me/send-code")
-    public CommonApiResponse sendCode(
+    public CommonApiMessageResponse sendCode(
             @RequestBody @Valid GenerateCodeReqDto reqDto
     ) {
         generateCodeService.execute(manager.getId(), reqDto);
-        return CommonApiResponse.success("전송되었습니다.");
+        return CommonApiMessageResponse.success("전송되었습니다.");
     }
 
     @PostMapping("/applicant/me/send-code-test")
-    public CommonApiResponse sendCodeTest(
+    public CommonApiMessageResponse sendCodeTest(
             @RequestBody @Valid GenerateCodeReqDto reqDto
     ) {
         String code = generateTestCodeService.execute(manager.getId(), reqDto);
-        return CommonApiResponse.success("전송되었습니다. : " + code);
+        return CommonApiMessageResponse.success("전송되었습니다. : " + code);
     }
 
     @PostMapping("/applicant/me/auth-code")
-    public CommonApiResponse authCode(
+    public CommonApiMessageResponse authCode(
             @RequestBody @Valid AuthenticateCodeReqDto reqDto
     ) {
         authenticateCodeService.execute(manager.getId(), reqDto);
-        return CommonApiResponse.success("인증되었습니다.");
+        return CommonApiMessageResponse.success("인증되었습니다.");
     }
 
     @PostMapping("/applicant/me")
-    public CommonApiResponse create(
+    public CommonApiMessageResponse create(
             HttpServletRequest httpServletRequest,
             @RequestBody @Valid ApplicantReqDto reqDto
     ) {
         Role role = createApplicantService.execute(reqDto, manager.getId());
         manager.setRole(httpServletRequest, role);
-        return CommonApiResponse.created("본인인증이 완료되었습니다.");
+        return CommonApiMessageResponse.created("본인인증이 완료되었습니다.");
     }
 
     @PutMapping("/applicant/me")
-    public CommonApiResponse modify(
+    public CommonApiMessageResponse modify(
             @RequestBody @Valid ApplicantReqDto reqDto
     ) {
         modifyApplicantService.execute(reqDto, manager.getId());
-        return CommonApiResponse.success("수정되었습니다.");
+        return CommonApiMessageResponse.success("수정되었습니다.");
     }
 
     @GetMapping("/applicant/me")

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
@@ -34,58 +34,58 @@ public class ApplicantController {
     private final GenerateCodeServiceImpl generateCodeService;
 
     @PostMapping("/applicant/me/send-code")
-    public ResponseEntity<CommonApiResponse> sendCode(
+    public CommonApiResponse sendCode(
             @RequestBody @Valid GenerateCodeReqDto reqDto
     ) {
         generateCodeService.execute(manager.getId(), reqDto);
-        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("전송되었습니다."));
+        return CommonApiResponse.success("전송되었습니다.");
     }
 
     @PostMapping("/applicant/me/send-code-test")
-    public ResponseEntity<CommonApiResponse> sendCodeTest(
+    public CommonApiResponse sendCodeTest(
             @RequestBody @Valid GenerateCodeReqDto reqDto
     ) {
         String code = generateTestCodeService.execute(manager.getId(), reqDto);
-        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("전송되었습니다. : " + code));
+        return CommonApiResponse.success("전송되었습니다. : " + code);
     }
 
     @PostMapping("/applicant/me/auth-code")
-    public ResponseEntity<CommonApiResponse> authCode(
+    public CommonApiResponse authCode(
             @RequestBody @Valid AuthenticateCodeReqDto reqDto
     ) {
         authenticateCodeService.execute(manager.getId(), reqDto);
-        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("인증되었습니다."));
+        return CommonApiResponse.success("인증되었습니다.");
     }
 
     @PostMapping("/applicant/me")
-    public ResponseEntity<CommonApiResponse> create(
+    public CommonApiResponse create(
             HttpServletRequest httpServletRequest,
             @RequestBody @Valid ApplicantReqDto reqDto
     ) {
         Role role = createApplicantService.execute(reqDto, manager.getId());
         manager.setRole(httpServletRequest, role);
-        return ResponseEntity.status(HttpStatus.CREATED).body(CommonApiResponse.success("본인인증이 완료되었습니다"));
+        return CommonApiResponse.created("본인인증이 완료되었습니다");
     }
 
     @PutMapping("/applicant/me")
-    public ResponseEntity<CommonApiResponse> modify(
+    public CommonApiResponse modify(
             @RequestBody @Valid ApplicantReqDto reqDto
     ) {
         modifyApplicantService.execute(reqDto, manager.getId());
-        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("수정되었습니다"));
+        return CommonApiResponse.success("수정되었습니다");
     }
 
     @GetMapping("/applicant/me")
-    public ResponseEntity<FoundApplicantResDto> find() {
+    public FoundApplicantResDto find() {
         FoundApplicantResDto foundApplicantResDto = queryApplicantByIdService.execute(manager.getId());
-        return ResponseEntity.status(HttpStatus.OK).body(foundApplicantResDto);
+        return foundApplicantResDto;
     }
 
     @GetMapping("/applicant/{authenticationId}")
-    public ResponseEntity<FoundApplicantResDto> findByUserId(
+    public FoundApplicantResDto findByUserId(
             @PathVariable Long authenticationId
     ) {
         FoundApplicantResDto foundApplicantResDto = queryApplicantByIdService.execute(authenticationId);
-        return ResponseEntity.status(HttpStatus.OK).body(foundApplicantResDto);
+        return foundApplicantResDto;
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/applicant/controller/ApplicantController.java
@@ -13,16 +13,12 @@ import team.themoment.hellogsmv3.domain.applicant.service.QueryApplicantByIdServ
 import team.themoment.hellogsmv3.domain.applicant.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsmv3.domain.applicant.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsmv3.domain.applicant.service.AuthenticateCodeService;
-import team.themoment.hellogsmv3.domain.applicant.service.CreateApplicantService;
-import team.themoment.hellogsmv3.domain.applicant.service.GenerateCodeService;
 import team.themoment.hellogsmv3.domain.applicant.service.ModifyApplicantService;
 import team.themoment.hellogsmv3.domain.applicant.service.impl.GenerateCodeServiceImpl;
 import team.themoment.hellogsmv3.domain.applicant.service.impl.GenerateTestCodeServiceImpl;
 import team.themoment.hellogsmv3.domain.auth.type.Role;
-import team.themoment.hellogsmv3.global.common.response.ApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 import team.themoment.hellogsmv3.global.security.auth.AuthenticatedUserManager;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/applicant/v3")
@@ -38,45 +34,45 @@ public class ApplicantController {
     private final GenerateCodeServiceImpl generateCodeService;
 
     @PostMapping("/applicant/me/send-code")
-    public ResponseEntity<ApiResponse> sendCode(
+    public ResponseEntity<CommonApiResponse> sendCode(
             @RequestBody @Valid GenerateCodeReqDto reqDto
     ) {
         generateCodeService.execute(manager.getId(), reqDto);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("전송되었습니다."));
+        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("전송되었습니다."));
     }
 
     @PostMapping("/applicant/me/send-code-test")
-    public ResponseEntity<ApiResponse> sendCodeTest(
+    public ResponseEntity<CommonApiResponse> sendCodeTest(
             @RequestBody @Valid GenerateCodeReqDto reqDto
     ) {
         String code = generateTestCodeService.execute(manager.getId(), reqDto);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("전송되었습니다. : " + code));
+        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("전송되었습니다. : " + code));
     }
 
     @PostMapping("/applicant/me/auth-code")
-    public ResponseEntity<ApiResponse> authCode(
+    public ResponseEntity<CommonApiResponse> authCode(
             @RequestBody @Valid AuthenticateCodeReqDto reqDto
     ) {
         authenticateCodeService.execute(manager.getId(), reqDto);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("인증되었습니다."));
+        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("인증되었습니다."));
     }
 
     @PostMapping("/applicant/me")
-    public ResponseEntity<ApiResponse> create(
+    public ResponseEntity<CommonApiResponse> create(
             HttpServletRequest httpServletRequest,
             @RequestBody @Valid ApplicantReqDto reqDto
     ) {
         Role role = createApplicantService.execute(reqDto, manager.getId());
         manager.setRole(httpServletRequest, role);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("본인인증이 완료되었습니다"));
+        return ResponseEntity.status(HttpStatus.CREATED).body(CommonApiResponse.success("본인인증이 완료되었습니다"));
     }
 
     @PutMapping("/applicant/me")
-    public ResponseEntity<ApiResponse> modify(
+    public ResponseEntity<CommonApiResponse> modify(
             @RequestBody @Valid ApplicantReqDto reqDto
     ) {
         modifyApplicantService.execute(reqDto, manager.getId());
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("수정되었습니다"));
+        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("수정되었습니다"));
     }
 
     @GetMapping("/applicant/me")

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
@@ -9,7 +9,7 @@ import team.themoment.hellogsmv3.domain.application.dto.request.ApplicationReqDt
 import team.themoment.hellogsmv3.domain.application.service.CreateApplicationService;
 import team.themoment.hellogsmv3.domain.application.service.ModifyApplicationService;
 import team.themoment.hellogsmv3.domain.application.service.UpdateFinalSubmissionService;
-import team.themoment.hellogsmv3.global.common.response.ApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 import team.themoment.hellogsmv3.global.security.auth.AuthenticatedUserManager;
 
 @RestController
@@ -23,29 +23,29 @@ public class ApplicationController {
     private final UpdateFinalSubmissionService updateFinalSubmissionService;
 
     @PostMapping("/application/me")
-    public ResponseEntity<ApiResponse> create(@RequestBody @Valid ApplicationReqDto reqDto) {
+    public ResponseEntity<CommonApiResponse> create(@RequestBody @Valid ApplicationReqDto reqDto) {
         createApplicationService.execute(reqDto, manager.getId());
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("생성되었습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(CommonApiResponse.success("생성되었습니다."));
     }
 
     @PutMapping("/application/me")
-    public ResponseEntity<ApiResponse> modify(@RequestBody @Valid ApplicationReqDto reqDto) {
+    public ResponseEntity<CommonApiResponse> modify(@RequestBody @Valid ApplicationReqDto reqDto) {
         modifyApplicationService.execute(reqDto, manager.getId(), false);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("수정되었습니다."));
+        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("수정되었습니다."));
     }
 
     @PutMapping("/application/{applicantId}")
-    public ResponseEntity<ApiResponse> modifyOne(
+    public ResponseEntity<CommonApiResponse> modifyOne(
             @RequestBody @Valid ApplicationReqDto reqDto,
             @PathVariable Long applicantId) {
         modifyApplicationService.execute(reqDto, applicantId, true);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("수정되었습니다."));
+        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("수정되었습니다."));
     }
 
     @PutMapping("/final-submit")
-    public ResponseEntity<ApiResponse> finalSubmission() {
+    public ResponseEntity<CommonApiResponse> finalSubmission() {
         updateFinalSubmissionService.execute(manager.getId());
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("수정되었습니다."));
+        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("수정되었습니다."));
     }
 
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
@@ -2,14 +2,12 @@ package team.themoment.hellogsmv3.domain.application.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsmv3.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.hellogsmv3.domain.application.service.CreateApplicationService;
 import team.themoment.hellogsmv3.domain.application.service.ModifyApplicationService;
 import team.themoment.hellogsmv3.domain.application.service.UpdateFinalSubmissionService;
-import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiMessageResponse;
 import team.themoment.hellogsmv3.global.security.auth.AuthenticatedUserManager;
 
 @RestController
@@ -23,29 +21,29 @@ public class ApplicationController {
     private final UpdateFinalSubmissionService updateFinalSubmissionService;
 
     @PostMapping("/application/me")
-    public CommonApiResponse create(@RequestBody @Valid ApplicationReqDto reqDto) {
+    public CommonApiMessageResponse create(@RequestBody @Valid ApplicationReqDto reqDto) {
         createApplicationService.execute(reqDto, manager.getId());
-        return CommonApiResponse.created("생성되었습니다.");
+        return CommonApiMessageResponse.created("생성되었습니다.");
     }
 
     @PutMapping("/application/me")
-    public CommonApiResponse modify(@RequestBody @Valid ApplicationReqDto reqDto) {
+    public CommonApiMessageResponse modify(@RequestBody @Valid ApplicationReqDto reqDto) {
         modifyApplicationService.execute(reqDto, manager.getId(), false);
-        return CommonApiResponse.success("수정되었습니다.");
+        return CommonApiMessageResponse.success("수정되었습니다.");
     }
 
     @PutMapping("/application/{applicantId}")
-    public CommonApiResponse modifyOne(
+    public CommonApiMessageResponse modifyOne(
             @RequestBody @Valid ApplicationReqDto reqDto,
             @PathVariable Long applicantId) {
         modifyApplicationService.execute(reqDto, applicantId, true);
-        return CommonApiResponse.success("수정되었습니다.");
+        return CommonApiMessageResponse.success("수정되었습니다.");
     }
 
     @PutMapping("/final-submit")
-    public CommonApiResponse finalSubmission() {
+    public CommonApiMessageResponse finalSubmission() {
         updateFinalSubmissionService.execute(manager.getId());
-        return CommonApiResponse.success("수정되었습니다.");
+        return CommonApiMessageResponse.success("수정되었습니다.");
     }
 
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
@@ -23,29 +23,29 @@ public class ApplicationController {
     private final UpdateFinalSubmissionService updateFinalSubmissionService;
 
     @PostMapping("/application/me")
-    public ResponseEntity<CommonApiResponse> create(@RequestBody @Valid ApplicationReqDto reqDto) {
+    public CommonApiResponse create(@RequestBody @Valid ApplicationReqDto reqDto) {
         createApplicationService.execute(reqDto, manager.getId());
-        return ResponseEntity.status(HttpStatus.CREATED).body(CommonApiResponse.success("생성되었습니다."));
+        return CommonApiResponse.created("생성되었습니다.");
     }
 
     @PutMapping("/application/me")
-    public ResponseEntity<CommonApiResponse> modify(@RequestBody @Valid ApplicationReqDto reqDto) {
+    public CommonApiResponse modify(@RequestBody @Valid ApplicationReqDto reqDto) {
         modifyApplicationService.execute(reqDto, manager.getId(), false);
-        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("수정되었습니다."));
+        return CommonApiResponse.success("수정되었습니다.");
     }
 
     @PutMapping("/application/{applicantId}")
-    public ResponseEntity<CommonApiResponse> modifyOne(
+    public CommonApiResponse modifyOne(
             @RequestBody @Valid ApplicationReqDto reqDto,
             @PathVariable Long applicantId) {
         modifyApplicationService.execute(reqDto, applicantId, true);
-        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("수정되었습니다."));
+        return CommonApiResponse.success("수정되었습니다.");
     }
 
     @PutMapping("/final-submit")
-    public ResponseEntity<CommonApiResponse> finalSubmission() {
+    public CommonApiResponse finalSubmission() {
         updateFinalSubmissionService.execute(manager.getId());
-        return ResponseEntity.status(HttpStatus.OK).body(CommonApiResponse.success("수정되었습니다."));
+        return CommonApiResponse.success("수정되었습니다.");
     }
 
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/auth/controller/AuthenticationController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/auth/controller/AuthenticationController.java
@@ -12,21 +12,18 @@ import team.themoment.hellogsmv3.global.security.auth.AuthenticatedUserManager;
 @RequiredArgsConstructor
 public class AuthenticationController {
 
-    private final AuthenticatedUserManager authenticatedUserManager;
+    private final AuthenticatedUserManager manager;
     private final QueryAuthenticationById queryAuthenticationById;
 
     @GetMapping("/authentication/{authenticationId}")
-    public ResponseEntity<BasicAuthenticationDto> getAuthenticationInfo(
+    public BasicAuthenticationDto getAuthenticationInfo(
             @PathVariable Long authenticationId
     ) {
-        BasicAuthenticationDto authenticationDto = queryAuthenticationById.execute(authenticationId);
-        return ResponseEntity.ok(authenticationDto);
+        return queryAuthenticationById.execute(authenticationId);
     }
 
     @GetMapping("/authentication/me")
-    public ResponseEntity<BasicAuthenticationDto> getMyAuthenticationInfo() {
-        Long authenticationId = authenticatedUserManager.getId();
-        BasicAuthenticationDto authenticationDto = queryAuthenticationById.execute(authenticationId);
-        return ResponseEntity.ok(authenticationDto);
+    public BasicAuthenticationDto getMyAuthenticationInfo() {
+        return queryAuthenticationById.execute(manager.getId());
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/common/response/ApiResponse.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/response/ApiResponse.java
@@ -1,9 +1,0 @@
-package team.themoment.hellogsmv3.global.common.response;
-
-import jakarta.annotation.Nonnull;
-
-public record ApiResponse (String message) {
-    public static ApiResponse success(@Nonnull String message) {
-        return new ApiResponse(message);
-    }
-}

--- a/src/main/java/team/themoment/hellogsmv3/global/common/response/ApiResponseWrapper.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/response/ApiResponseWrapper.java
@@ -59,11 +59,7 @@ public class ApiResponseWrapper implements ResponseBodyAdvice<Object> {
             int statusCode = (int) bodyMap.get("status");
             if (statusCode >= 400 && statusCode < 600) {
                 HttpStatus status = HttpStatus.valueOf(statusCode);
-                CommonApiMessageResponse<Object> errorResponse = new CommonApiMessageResponse<>(
-                        status,
-                        statusCode,
-                        status.getReasonPhrase()
-                );
+                CommonApiMessageResponse errorResponse = CommonApiMessageResponse.error(status.getReasonPhrase(), status);
                 response.setStatusCode(HttpStatusCode.valueOf(statusCode));
                 return errorResponse;
             }

--- a/src/main/java/team/themoment/hellogsmv3/global/common/response/ApiResponseWrapper.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/response/ApiResponseWrapper.java
@@ -1,0 +1,42 @@
+package team.themoment.hellogsmv3.global.common.response;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class ApiResponseWrapper implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  org.springframework.http.MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request, ServerHttpResponse response) {
+
+        if (body instanceof CommonApiResponse) {
+            CommonApiResponse<?> commonApiResponse = (CommonApiResponse<?>) body;
+            response.setStatusCode(commonApiResponse.status());
+            return body;
+        }
+
+        CommonApiResponse<Object> commonApiResponse = new CommonApiResponse<>(
+                HttpStatus.OK,
+                HttpStatus.OK.value(),
+                "OK",
+                body
+        );
+
+        response.setStatusCode(HttpStatus.OK);
+        return commonApiResponse;
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/common/response/CommonApiMessageResponse.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/response/CommonApiMessageResponse.java
@@ -1,0 +1,22 @@
+package team.themoment.hellogsmv3.global.common.response;
+
+import jakarta.annotation.Nonnull;
+import org.springframework.http.HttpStatus;
+
+public record CommonApiMessageResponse<T>(
+        HttpStatus status,
+        int code,
+        String message
+) {
+    public static CommonApiMessageResponse success(@Nonnull String message) {
+        return new CommonApiMessageResponse(HttpStatus.OK, HttpStatus.OK.value(), message);
+    }
+
+    public static CommonApiMessageResponse created(@Nonnull String message) {
+        return new CommonApiMessageResponse(HttpStatus.CREATED, HttpStatus.CREATED.value(), message);
+    }
+
+    public static CommonApiMessageResponse error(@Nonnull String message, @Nonnull HttpStatus status) {
+        return new CommonApiMessageResponse(status, status.value(), message);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/common/response/CommonApiResponse.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/response/CommonApiResponse.java
@@ -1,9 +1,24 @@
 package team.themoment.hellogsmv3.global.common.response;
 
 import jakarta.annotation.Nonnull;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 
-public record CommonApiResponse(String message) {
+public record CommonApiResponse<T>(
+        HttpStatus status,
+        int code,
+        String message,
+        T data
+) {
     public static CommonApiResponse success(@Nonnull String message) {
-        return new CommonApiResponse(message);
+        return new CommonApiResponse(HttpStatus.OK, HttpStatus.OK.value(), message, null);
+    }
+
+    public static CommonApiResponse created(@Nonnull String message) {
+        return new CommonApiResponse(HttpStatus.CREATED, HttpStatus.CREATED.value(), message, null);
+    }
+
+    public static CommonApiResponse error(@Nonnull String message, @Nonnull HttpStatus status) {
+        return new CommonApiResponse(status, status.value(), message, null);
     }
 }

--- a/src/main/java/team/themoment/hellogsmv3/global/common/response/CommonApiResponse.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/response/CommonApiResponse.java
@@ -1,0 +1,9 @@
+package team.themoment.hellogsmv3.global.common.response;
+
+import jakarta.annotation.Nonnull;
+
+public record CommonApiResponse(String message) {
+    public static CommonApiResponse success(@Nonnull String message) {
+        return new CommonApiResponse(message);
+    }
+}

--- a/src/main/java/team/themoment/hellogsmv3/global/common/response/CommonApiResponse.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/common/response/CommonApiResponse.java
@@ -9,16 +9,4 @@ public record CommonApiResponse<T>(
         int code,
         String message,
         T data
-) {
-    public static CommonApiResponse success(@Nonnull String message) {
-        return new CommonApiResponse(HttpStatus.OK, HttpStatus.OK.value(), message, null);
-    }
-
-    public static CommonApiResponse created(@Nonnull String message) {
-        return new CommonApiResponse(HttpStatus.CREATED, HttpStatus.CREATED.value(), message, null);
-    }
-
-    public static CommonApiResponse error(@Nonnull String message, @Nonnull HttpStatus status) {
-        return new CommonApiResponse(status, status.value(), message, null);
-    }
-}
+) { }

--- a/src/main/java/team/themoment/hellogsmv3/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
 import team.themoment.hellogsmv3.global.exception.model.ExceptionResponseEntity;
 
@@ -24,50 +25,44 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ExpectedException.class)
-    private ResponseEntity<ExceptionResponseEntity> expectedException(ExpectedException ex) {
+    private CommonApiResponse expectedException(ExpectedException ex) {
         log.warn("ExpectedException : {} ", ex.getMessage());
         log.trace("ExpectedException Details : ", ex);
-        return ResponseEntity.status(ex.getStatusCode().value())
-                .body(ExceptionResponseEntity.of(ex));
+        return CommonApiResponse.error(ex.getMessage(), ex.getStatusCode());
     }
 
     @ExceptionHandler({MethodArgumentNotValidException.class, HttpMessageNotReadableException.class})
-    public ResponseEntity<ExceptionResponseEntity> validationException(MethodArgumentNotValidException ex) {
+    public CommonApiResponse validationException(MethodArgumentNotValidException ex) {
         log.warn("Validation Failed : {}", ex.getMessage());
         log.trace("Validation Failed Details : ", ex);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
-                .body(new ExceptionResponseEntity(methodArgumentNotValidExceptionToJson(ex)));
+        return CommonApiResponse.error(methodArgumentNotValidExceptionToJson(ex), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ExceptionResponseEntity> validationException(ConstraintViolationException ex) {
+    public CommonApiResponse validationException(ConstraintViolationException ex) {
         log.warn("field validation failed : {}", ex.getMessage());
         log.trace("field validation failed : ", ex);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
-                .body(new ExceptionResponseEntity("field validation failed : " + ex.getMessage()));
+        return CommonApiResponse.error("field validation failed : " + ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ExceptionResponseEntity> unExpectedException(RuntimeException ex) {
+    public CommonApiResponse unExpectedException(RuntimeException ex) {
         log.error("UnExpectedException Occur : ", ex);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR.value())
-                .body(new ExceptionResponseEntity("internal server error has occurred"));
+        return CommonApiResponse.error("internal server error has occurred", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<ExceptionResponseEntity> noHandlerFoundException(NoHandlerFoundException ex) {
+    public CommonApiResponse noHandlerFoundException(NoHandlerFoundException ex) {
         log.warn("Not Found Endpoint : {}", ex.getMessage());
         log.trace("Not Found Endpoint Details : ", ex);
-        return ResponseEntity.status(ex.getStatusCode())
-                .body(new ExceptionResponseEntity(HttpStatus.NOT_FOUND.getReasonPhrase()));
+        return CommonApiResponse.error(ex.getMessage(), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<ExceptionResponseEntity> maxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
+    public CommonApiResponse maxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
         log.warn("The file is too big : {}", ex.getMessage());
         log.trace("The file is too big Details : ", ex);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
-                .body(new ExceptionResponseEntity("The file is too big, limited file size : " + ex.getMaxUploadSize()));
+        return CommonApiResponse.error("The file is too big, limited file size : " + ex.getMaxUploadSize(), HttpStatus.BAD_REQUEST);
     }
 
     private static String methodArgumentNotValidExceptionToJson(MethodArgumentNotValidException ex) {

--- a/src/main/java/team/themoment/hellogsmv3/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/exception/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONObject;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,9 +11,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import team.themoment.hellogsmv3.global.common.response.CommonApiResponse;
+import team.themoment.hellogsmv3.global.common.response.CommonApiMessageResponse;
 import team.themoment.hellogsmv3.global.exception.error.ExpectedException;
-import team.themoment.hellogsmv3.global.exception.model.ExceptionResponseEntity;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,44 +23,44 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ExpectedException.class)
-    private CommonApiResponse expectedException(ExpectedException ex) {
+    private CommonApiMessageResponse expectedException(ExpectedException ex) {
         log.warn("ExpectedException : {} ", ex.getMessage());
         log.trace("ExpectedException Details : ", ex);
-        return CommonApiResponse.error(ex.getMessage(), ex.getStatusCode());
+        return CommonApiMessageResponse.error(ex.getMessage(), ex.getStatusCode());
     }
 
     @ExceptionHandler({MethodArgumentNotValidException.class, HttpMessageNotReadableException.class})
-    public CommonApiResponse validationException(MethodArgumentNotValidException ex) {
+    public CommonApiMessageResponse validationException(MethodArgumentNotValidException ex) {
         log.warn("Validation Failed : {}", ex.getMessage());
         log.trace("Validation Failed Details : ", ex);
-        return CommonApiResponse.error(methodArgumentNotValidExceptionToJson(ex), HttpStatus.BAD_REQUEST);
+        return CommonApiMessageResponse.error(methodArgumentNotValidExceptionToJson(ex), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
-    public CommonApiResponse validationException(ConstraintViolationException ex) {
+    public CommonApiMessageResponse validationException(ConstraintViolationException ex) {
         log.warn("field validation failed : {}", ex.getMessage());
         log.trace("field validation failed : ", ex);
-        return CommonApiResponse.error("field validation failed : " + ex.getMessage(), HttpStatus.BAD_REQUEST);
+        return CommonApiMessageResponse.error("field validation failed : " + ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(RuntimeException.class)
-    public CommonApiResponse unExpectedException(RuntimeException ex) {
+    public CommonApiMessageResponse unExpectedException(RuntimeException ex) {
         log.error("UnExpectedException Occur : ", ex);
-        return CommonApiResponse.error("internal server error has occurred", HttpStatus.INTERNAL_SERVER_ERROR);
+        return CommonApiMessageResponse.error("internal server error has occurred", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    public CommonApiResponse noHandlerFoundException(NoHandlerFoundException ex) {
+    public CommonApiMessageResponse noHandlerFoundException(NoHandlerFoundException ex) {
         log.warn("Not Found Endpoint : {}", ex.getMessage());
         log.trace("Not Found Endpoint Details : ", ex);
-        return CommonApiResponse.error(ex.getMessage(), HttpStatus.NOT_FOUND);
+        return CommonApiMessageResponse.error(ex.getMessage(), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public CommonApiResponse maxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
+    public CommonApiMessageResponse maxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
         log.warn("The file is too big : {}", ex.getMessage());
         log.trace("The file is too big Details : ", ex);
-        return CommonApiResponse.error("The file is too big, limited file size : " + ex.getMaxUploadSize(), HttpStatus.BAD_REQUEST);
+        return CommonApiMessageResponse.error("The file is too big, limited file size : " + ex.getMaxUploadSize(), HttpStatus.BAD_REQUEST);
     }
 
     private static String methodArgumentNotValidExceptionToJson(MethodArgumentNotValidException ex) {

--- a/src/main/java/team/themoment/hellogsmv3/global/exception/model/ExceptionResponseEntity.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/exception/model/ExceptionResponseEntity.java
@@ -1,9 +1,0 @@
-package team.themoment.hellogsmv3.global.exception.model;
-
-public record ExceptionResponseEntity(String message) {
-
-    public static ExceptionResponseEntity of(final Throwable exception) {
-        return new ExceptionResponseEntity(exception.getMessage());
-    }
-
-}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,12 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             authorization-uri: https://kauth.kakao.com/oauth/authorize
 
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
+
 auth:
   redirect-base-uri: http://localhost:8080/
   redirect-login-failure-uri: http://localhost:8080/auth/error


### PR DESCRIPTION
## 개요

모든 controller에서 response값을 `ResponseEntity<>`에 감싸서 반환하고 있어 해당 부분을 공통화 처리하였습니다.

## 본문

- `CommonApiMessageResponse` 객체를 두어 기존엔 메시지를 반환할때 Map객체를 넘겨주었지만 해당 객체의 정적 메서드를 통해 response하여 안정성을 높혔습니다.
- controller response값에 `ResponseEntity<>`를 감싸서 반환하는 부분을 controlleradvice에서 처리하도록 하여 종복되는 부분을 제거하였습니다.
   - body가 있는 response는 controlleradvice에서 `CommonApiResponse` 객체에 상태코드와 함께 담아 반환해줍니다.
   - 만약 `CommonApiMessageResponse` 객체가 반환된다면 `instanceof`로 잡아서 by-pass 해주도록 구현하였습니다.

### 기타

<img width="709" alt="스크린샷 2024-06-18 오전 11 08 14" src="https://github.com/themoment-team/hellogsm-server-v3/assets/131235625/b794bacf-4937-4ed8-84fb-190efa29a244">

기존에 `NoHandlerFoundException` 해당 예외를 핸들링하는 메서드가 존재하였는데 해당 예외가 발생하여도 예외가 핸들링되지 않는 현상이 발생하였습니다.
`NoHandlerFoundException` 예외에 대해 조사해보니 아래의 설정이 application.yml에 작성되어 있어야 핸들링 된다고 하여 아래의 내용을 추가하였습니다.

```yml
  mvc:
    throw-exception-if-no-handler-found: true
  web:
    resources:
      add-mappings: false
```

설정 추가 후에는 잘 핸들링 되는 모습을 확인하였습니다.