### PR TITLE
[application] 변경된 원서 도메인에 맞춰 원서 생성, 수정 로직 변경

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/application/entity/CandidateMiddleSchoolGrade.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/entity/CandidateMiddleSchoolGrade.java
@@ -37,8 +37,7 @@ public final class CandidateMiddleSchoolGrade extends AbstractMiddleSchoolGrade 
 
     private BigDecimal extraCurricularSubtotalScore;
 
-    private BigDecimal totalScore;
-  
+    @Builder
     public CandidateMiddleSchoolGrade(
             UUID id,
             @NonNull CandidateMiddleSchoolGradeParameter parameter

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/CreateApplicationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/CreateApplicationService.java
@@ -82,6 +82,7 @@ public class CreateApplicationService {
                         .phoneNumber(dto.telephone())
                         .guardianName(dto.guardianName())
                         .relationWithApplicant(dto.relationWithApplicant())
+                        .guardianPhoneNumber(dto.guardianPhoneNumber())
                         .build())
                 .schoolName(dto.schoolName())
                 .schoolLocation(dto.schoolLocation())
@@ -153,6 +154,7 @@ public class CreateApplicationService {
                         .phoneNumber(dto.telephone())
                         .guardianName(dto.guardianName())
                         .relationWithApplicant(dto.relationWithApplicant())
+                        .guardianPhoneNumber(dto.guardianPhoneNumber())
                         .build())
                 .schoolName(dto.schoolName())
                 .schoolLocation(dto.schoolLocation())
@@ -213,6 +215,7 @@ public class CreateApplicationService {
                         .phoneNumber(dto.telephone())
                         .guardianName(dto.guardianName())
                         .relationWithApplicant(dto.relationWithApplicant())
+                        .guardianPhoneNumber(dto.guardianPhoneNumber())
                         .build())
                 .build();
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/CreateApplicationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/CreateApplicationService.java
@@ -47,7 +47,7 @@ public class CreateApplicationService {
 
     private void saveCandidateApplication(ApplicationReqDto dto, Applicant currentApplicant) {
         CandidatePersonalInformation candidatePersonalInformation = buildCandidatePersonalInformation(dto);
-        CandidateMiddleSchoolGrade candidateMiddleSchoolGrade = buildCandidateMiddleSchoolGrade();
+        CandidateMiddleSchoolGrade candidateMiddleSchoolGrade = buildCandidateMiddleSchoolGrade(dto);
         CandidateApplication candidateApplication = buildCandidateApplication(
                 dto, candidatePersonalInformation, candidateMiddleSchoolGrade, currentApplicant);
 
@@ -56,7 +56,7 @@ public class CreateApplicationService {
 
     private void saveGedApplication(ApplicationReqDto dto, Applicant currentApplicant) {
         GedPersonalInformation gedPersonalInformation = buildGedPersonalInformation(dto);
-        GedMiddleSchoolGrade gedMiddleSchoolGrade = buildGedMiddleSchoolGrade();
+        GedMiddleSchoolGrade gedMiddleSchoolGrade = buildGedMiddleSchoolGrade(dto);
         GedApplication gedApplication = buildGedApplication(
                 dto, gedPersonalInformation, gedMiddleSchoolGrade, currentApplicant);
 
@@ -65,7 +65,7 @@ public class CreateApplicationService {
 
     private void saveGraduateApplication(ApplicationReqDto dto, Applicant currentApplicant) {
         GraduatePersonalInformation graduatePersonalInformation = buildGraduatePersonalInformation(dto);
-        GraduateMiddleSchoolGrade graduateMiddleSchoolGrade = buildGraduateMiddleSchoolGrade();
+        GraduateMiddleSchoolGrade graduateMiddleSchoolGrade = buildGraduateMiddleSchoolGrade(dto);
         GraduateApplication graduateApplication = buildGraduateApplication(
                 dto, graduatePersonalInformation, graduateMiddleSchoolGrade, currentApplicant);
 
@@ -90,11 +90,11 @@ public class CreateApplicationService {
                 .build();
     }
 
-    private CandidateMiddleSchoolGrade buildCandidateMiddleSchoolGrade() {
+    private CandidateMiddleSchoolGrade buildCandidateMiddleSchoolGrade(ApplicationReqDto dto) {
         return CandidateMiddleSchoolGrade.builder()
                 // TODO 환산 로직은 추후 구현 예정
                 .parameter(CandidateMiddleSchoolGradeParameter.builder()
-                        .transcript(new MiddleSchoolTranscript())
+                        .transcript(dto.middleSchoolGrade())
                         .grade1Semester1Score(BigDecimal.ONE)
                         .grade1Semester2Score(BigDecimal.ONE)
                         .grade2Semester1Score(BigDecimal.ONE)
@@ -161,12 +161,14 @@ public class CreateApplicationService {
                 .build();
     }
 
-    private GraduateMiddleSchoolGrade buildGraduateMiddleSchoolGrade() {
+    private GraduateMiddleSchoolGrade buildGraduateMiddleSchoolGrade(ApplicationReqDto dto) {
         return GraduateMiddleSchoolGrade.builder()
                 // TODO 환산 로직은 추후 구현 예정
+                .transcript(dto.middleSchoolGrade())
                 .percentileRank(BigDecimal.ONE)
                 .attendanceScore(BigDecimal.ONE)
                 .volunteerScore(BigDecimal.ONE)
+                .totalScore(BigDecimal.ONE)
                 .build();
     }
 
@@ -215,12 +217,14 @@ public class CreateApplicationService {
                 .build();
     }
 
-    private GedMiddleSchoolGrade buildGedMiddleSchoolGrade() {
+    private GedMiddleSchoolGrade buildGedMiddleSchoolGrade(ApplicationReqDto dto) {
         return GedMiddleSchoolGrade.builder()
                 // TODO 환산 로직은 추후 구현 예정
+                .transcript(dto.middleSchoolGrade())
                 .percentileRank(BigDecimal.ONE)
                 .gedMaxScore(BigDecimal.ONE)
                 .gedTotalScore(BigDecimal.ONE)
+                .gedMaxScore(BigDecimal.ONE)
                 .build();
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/CreateApplicationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/CreateApplicationService.java
@@ -225,7 +225,7 @@ public class CreateApplicationService {
                 // TODO 환산 로직은 추후 구현 예정
                 .transcript(dto.middleSchoolGrade())
                 .percentileRank(BigDecimal.ONE)
-                .gedMaxScore(BigDecimal.ONE)
+                .totalScore(BigDecimal.ONE)
                 .gedTotalScore(BigDecimal.ONE)
                 .gedMaxScore(BigDecimal.ONE)
                 .build();

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/ModifyApplicationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/ModifyApplicationService.java
@@ -98,6 +98,7 @@ public class ModifyApplicationService {
                         .phoneNumber(dto.telephone())
                         .guardianName(dto.guardianName())
                         .relationWithApplicant(dto.relationWithApplicant())
+                        .guardianPhoneNumber(dto.guardianPhoneNumber())
                         .build())
                 .schoolName(dto.schoolName())
                 .schoolLocation(dto.schoolLocation())
@@ -167,6 +168,7 @@ public class ModifyApplicationService {
                         .phoneNumber(dto.telephone())
                         .guardianName(dto.guardianName())
                         .relationWithApplicant(dto.relationWithApplicant())
+                        .guardianPhoneNumber(dto.guardianPhoneNumber())
                         .build())
                 .schoolName(dto.schoolName())
                 .schoolLocation(dto.schoolLocation())
@@ -226,6 +228,7 @@ public class ModifyApplicationService {
                         .phoneNumber(dto.telephone())
                         .guardianName(dto.guardianName())
                         .relationWithApplicant(dto.relationWithApplicant())
+                        .guardianPhoneNumber(dto.guardianPhoneNumber())
                         .build())
                 .build();
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/ModifyApplicationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/ModifyApplicationService.java
@@ -62,7 +62,7 @@ public class ModifyApplicationService {
 
     private void saveUpdatedCandidateApplication(ApplicationReqDto dto, AbstractApplication application, Applicant applicant) {
         CandidatePersonalInformation candidatePersonalInformation = buildCandidatePersonalInformation(dto, application);
-        CandidateMiddleSchoolGrade candidateMiddleSchoolGrade = buildCandidateMiddleSchoolGrade(application);
+        CandidateMiddleSchoolGrade candidateMiddleSchoolGrade = buildCandidateMiddleSchoolGrade(dto, application);
         CandidateApplication candidateApplication = buildCandidateApplication(
                 dto, candidatePersonalInformation, candidateMiddleSchoolGrade, applicant, application);
 
@@ -71,7 +71,7 @@ public class ModifyApplicationService {
 
     private void saveUpdatedGraduateApplication(ApplicationReqDto dto, AbstractApplication application, Applicant applicant) {
         GraduatePersonalInformation graduatePersonalInformation = buildGraduatePersonalInformation(dto, application);
-        GraduateMiddleSchoolGrade graduateMiddleSchoolGrade = buildGraduateMiddleSchoolGrade(application);
+        GraduateMiddleSchoolGrade graduateMiddleSchoolGrade = buildGraduateMiddleSchoolGrade(dto, application);
         GraduateApplication graduateApplication = buildGraduateApplication(
                 dto, graduatePersonalInformation, graduateMiddleSchoolGrade, applicant, application);
 
@@ -80,7 +80,7 @@ public class ModifyApplicationService {
 
     private void saveUpdatedGedApplication(ApplicationReqDto dto, AbstractApplication application, Applicant applicant) {
         GedPersonalInformation gedPersonalInformation = buildGedPersonalInformation(dto, application);
-        GedMiddleSchoolGrade gedMiddleSchoolGrade = buildGedMiddleSchoolGrade(application);
+        GedMiddleSchoolGrade gedMiddleSchoolGrade = buildGedMiddleSchoolGrade(dto, application);
         GedApplication gedApplication = buildGedApplication(
                 dto, gedPersonalInformation, gedMiddleSchoolGrade, applicant, application);
 
@@ -106,12 +106,12 @@ public class ModifyApplicationService {
                 .build();
     }
 
-    private CandidateMiddleSchoolGrade buildCandidateMiddleSchoolGrade(AbstractApplication application) {
+    private CandidateMiddleSchoolGrade buildCandidateMiddleSchoolGrade(ApplicationReqDto dto, AbstractApplication application) {
         return CandidateMiddleSchoolGrade.builder()
                 // TODO 환산 로직은 추후 구현 예정
                 .id(application.getMiddleSchoolGrade().getId())
                 .parameter(CandidateMiddleSchoolGradeParameter.builder()
-                        .transcript(new MiddleSchoolTranscript())
+                        .transcript(dto.middleSchoolGrade())
                         .grade1Semester1Score(BigDecimal.ONE)
                         .grade1Semester2Score(BigDecimal.ONE)
                         .grade2Semester1Score(BigDecimal.ONE)
@@ -175,13 +175,15 @@ public class ModifyApplicationService {
                 .build();
     }
 
-    private GraduateMiddleSchoolGrade buildGraduateMiddleSchoolGrade(AbstractApplication application) {
+    private GraduateMiddleSchoolGrade buildGraduateMiddleSchoolGrade(ApplicationReqDto dto, AbstractApplication application) {
         return GraduateMiddleSchoolGrade.builder()
                 // TODO 환산 로직은 추후 구현 예정
                 .id(application.getMiddleSchoolGrade().getId())
+                .transcript(dto.middleSchoolGrade())
                 .percentileRank(BigDecimal.ONE)
                 .attendanceScore(BigDecimal.ONE)
                 .volunteerScore(BigDecimal.ONE)
+                .totalScore(BigDecimal.ONE)
                 .build();
     }
 
@@ -228,13 +230,15 @@ public class ModifyApplicationService {
                 .build();
     }
 
-    private GedMiddleSchoolGrade buildGedMiddleSchoolGrade(AbstractApplication application) {
+    private GedMiddleSchoolGrade buildGedMiddleSchoolGrade(ApplicationReqDto dto, AbstractApplication application) {
         return GedMiddleSchoolGrade.builder()
                 // TODO 환산 로직은 추후 구현 예정
                 .id(application.getMiddleSchoolGrade().getId())
+                .transcript(dto.middleSchoolGrade())
                 .percentileRank(BigDecimal.ONE)
                 .gedMaxScore(BigDecimal.ONE)
                 .gedTotalScore(BigDecimal.ONE)
+                .totalScore(BigDecimal.ONE)
                 .build();
     }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/type/EvaluationStatus.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/type/EvaluationStatus.java
@@ -3,6 +3,5 @@ package team.themoment.hellogsmv3.domain.application.type;
 public enum EvaluationStatus {
     NOT_YET,
     PASS,
-    FALL,
-    NOT_YET
+    FALL
 }


### PR DESCRIPTION
## 개요

변경된 원서 도메인의 필드에 맞춰서 원서 셍성, 수정 로직을 변경하였습니다.

## 본문

- `AbstractPersonalInformation` 엔티티에 누락된 필드인 `guardianPhoneNumber`가 추가되어 원서 생성, 수정 로직에 반영하였습니다.
- `AbstractMiddleSchoolGrade` 의 변경된 필드에 맞춰 생성, 수정 로직을 변경하였습니다.
- `EvaluationStatus`의 필드가 잘못 되어있어 수정하였습니다.
- `CandidateMiddleSchoolGrade`의 필요없는 필드를 제거하였습니다.