### PR TITLE
[application] 원서 도메인 심층면접 점수 필드 추가 및 EvaluationResult에 누락된 필드 추가

### DIFF
--- a/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
@@ -32,26 +32,26 @@ public class ApplicationController {
     private final UpdateFinalSubmissionService updateFinalSubmissionService;
 
     @GetMapping("/application/me")
-    public ResponseEntity<FoundApplicationResDto> findMe() {
+    public FoundApplicationResDto findMe() {
         FoundApplicationResDto foundApplicationResDto = queryApplicationByIdService.execute(manager.getId());
-        return ResponseEntity.status(HttpStatus.OK).body(foundApplicationResDto);
+        return foundApplicationResDto;
     }
 
     @GetMapping("/application/{applicantId}")
-    public ResponseEntity<FoundApplicationResDto> findOne(@PathVariable("applicantId") Long applicantId) {
+    public FoundApplicationResDto findOne(@PathVariable("applicantId") Long applicantId) {
         FoundApplicationResDto foundApplicationResDto = queryApplicationByIdService.execute(applicantId);
-        return ResponseEntity.status(HttpStatus.OK).body(foundApplicationResDto);
+        return foundApplicationResDto;
     }
 
     @GetMapping("/application/all")
-    public ResponseEntity<ApplicationListResDto> findAll(
+    public ApplicationListResDto findAll(
             @RequestParam("page") Integer page,
             @RequestParam("size") Integer size
     ) {
         if (page < 0 || size < 0)
             throw new ExpectedException("page, size는 0 이상만 가능합니다", HttpStatus.BAD_REQUEST);
         ApplicationListResDto applicationListResDto = queryAllApplicationService.execute(page, size);
-        return ResponseEntity.status(HttpStatus.OK).body(applicationListResDto);
+        return applicationListResDto;
     }
   
     @PostMapping("/application/me")

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/controller/ApplicationController.java
@@ -33,14 +33,12 @@ public class ApplicationController {
 
     @GetMapping("/application/me")
     public FoundApplicationResDto findMe() {
-        FoundApplicationResDto foundApplicationResDto = queryApplicationByIdService.execute(manager.getId());
-        return foundApplicationResDto;
+        return queryApplicationByIdService.execute(manager.getId());
     }
 
     @GetMapping("/application/{applicantId}")
     public FoundApplicationResDto findOne(@PathVariable("applicantId") Long applicantId) {
-        FoundApplicationResDto foundApplicationResDto = queryApplicationByIdService.execute(applicantId);
-        return foundApplicationResDto;
+        return queryApplicationByIdService.execute(applicantId);
     }
 
     @GetMapping("/application/all")
@@ -50,8 +48,7 @@ public class ApplicationController {
     ) {
         if (page < 0 || size < 0)
             throw new ExpectedException("page, size는 0 이상만 가능합니다", HttpStatus.BAD_REQUEST);
-        ApplicationListResDto applicationListResDto = queryAllApplicationService.execute(page, size);
-        return applicationListResDto;
+        return queryAllApplicationService.execute(page, size);
     }
   
     @PostMapping("/application/me")

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/AdmissionStatusResDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/AdmissionStatusResDto.java
@@ -17,6 +17,7 @@ public record AdmissionStatusResDto(
         Screening screeningSecondEvaluationAt,
         Long registrationNumber,
         BigDecimal secondScore,
+        BigDecimal interviewScore,
         Major finalMajor
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/ApplicationDto.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/dto/response/ApplicationDto.java
@@ -24,6 +24,7 @@ public record ApplicationDto(
         Screening screeningFirstEvaluationAt,
         Screening screeningSecondEvaluationAt,
         Long registrationNumber,
-        BigDecimal secondScore
+        BigDecimal secondScore,
+        BigDecimal interviewScore
 ) {
 }

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/entity/abs/AbstractApplication.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/entity/abs/AbstractApplication.java
@@ -50,7 +50,7 @@ public abstract class AbstractApplication {
             @AttributeOverride( name = "evaluationStatus", column = @Column(name = "subject_evaluation_result_status")),
             @AttributeOverride( name = "preScreeningEvaluation", column = @Column(name = "subject_evaluation_result_pre_screening")),
             @AttributeOverride( name = "postScreeningEvaluation", column = @Column(name = "subject_evaluation_result_post_screening")),
-            @AttributeOverride( name = "score", column = @Column(name = "subject_evaluation_result_score"))
+            @AttributeOverride( name = "score", column = @Column(name = "subject_evaluation_result_score")) // 1차 서류 전형 점수
     })
     protected EvaluationResult subjectEvaluationResult;
 
@@ -60,12 +60,12 @@ public abstract class AbstractApplication {
             @AttributeOverride( name = "evaluationStatus", column = @Column(name = "competency_evaluation_result_status")),
             @AttributeOverride( name = "preScreeningEvaluation", column = @Column(name = "competency_evaluation_result_pre_screening")),
             @AttributeOverride( name = "postScreeningEvaluation", column = @Column(name = "competency_evaluation_result_post_screening")),
-            @AttributeOverride( name = "score", column = @Column(name = "competency_evaluation_result_score"))
+            @AttributeOverride( name = "score", column = @Column(name = "competency_evaluation_result_score")) // 2차 인적성 검사 점수
     })
     protected EvaluationResult competencyEvaluationResult;
 
     @Nullable
-    protected BigDecimal competencyExamScore;
+    protected BigDecimal interviewScore; // 심층면접 점수
 
     @Nullable
     protected Long registrationNumber;

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryAllApplicationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryAllApplicationService.java
@@ -58,6 +58,7 @@ public class QueryAllApplicationService {
                             .screeningSecondEvaluationAt(application.getCompetencyEvaluationResult() != null ? application.getCompetencyEvaluationResult().getPostScreeningEvaluation() : null)
                             .registrationNumber(application.getRegistrationNumber())
                             .secondScore(application.getCompetencyEvaluationResult().getScore())
+                            .interviewScore(application.getInterviewScore())
                             .build());
         }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryAllApplicationService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryAllApplicationService.java
@@ -57,7 +57,7 @@ public class QueryAllApplicationService {
                             .screeningFirstEvaluationAt(application.getSubjectEvaluationResult() != null ? application.getSubjectEvaluationResult().getPostScreeningEvaluation() : null)
                             .screeningSecondEvaluationAt(application.getCompetencyEvaluationResult() != null ? application.getCompetencyEvaluationResult().getPostScreeningEvaluation() : null)
                             .registrationNumber(application.getRegistrationNumber())
-                            .secondScore(application.getCompetencyExamScore())
+                            .secondScore(application.getCompetencyEvaluationResult().getScore())
                             .build());
         }
 

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryApplicationByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryApplicationByIdService.java
@@ -148,6 +148,7 @@ public class QueryApplicationByIdService {
                 .screeningSecondEvaluationAt(application.getCompetencyEvaluationResult() != null ? application.getCompetencyEvaluationResult().getPostScreeningEvaluation() : null)
                 .registrationNumber(application.getRegistrationNumber())
                 .secondScore(application.getCompetencyEvaluationResult().getScore())
+                .interviewScore(application.getInterviewScore())
                 .finalMajor(application.getFinalMajor())
                 .build();
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryApplicationByIdService.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/service/QueryApplicationByIdService.java
@@ -147,7 +147,7 @@ public class QueryApplicationByIdService {
                 .screeningFirstEvaluationAt(application.getSubjectEvaluationResult() != null ? application.getSubjectEvaluationResult().getPostScreeningEvaluation() : null)
                 .screeningSecondEvaluationAt(application.getCompetencyEvaluationResult() != null ? application.getCompetencyEvaluationResult().getPostScreeningEvaluation() : null)
                 .registrationNumber(application.getRegistrationNumber())
-                .secondScore(application.getCompetencyExamScore())
+                .secondScore(application.getCompetencyEvaluationResult().getScore())
                 .finalMajor(application.getFinalMajor())
                 .build();
     }

--- a/src/main/java/team/themoment/hellogsmv3/domain/application/type/EvaluationResult.java
+++ b/src/main/java/team/themoment/hellogsmv3/domain/application/type/EvaluationResult.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.Objects;
 
 @Embeddable
@@ -20,6 +21,8 @@ public class EvaluationResult {
     private Screening preScreeningEvaluation;
 
     private Screening postScreeningEvaluation;
+
+    private BigDecimal score;
 
     public Boolean isPass() {
         return Objects.equals(evaluationStatus, EvaluationStatus.PASS);

--- a/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
+++ b/src/main/java/team/themoment/hellogsmv3/global/security/SecurityConfig.java
@@ -150,20 +150,17 @@ public class SecurityConfig {
                         Role.ROOT.name()
                 )
                 // application
-                .requestMatchers(HttpMethod.GET, "/application/v3/application/{applicantId}").hasAnyAuthority(
-                        Role.ADMIN.name()
-                )
                 .requestMatchers("/application/v3/application/me").hasAnyAuthority(
                         Role.APPLICANT.name()
+                )
+                .requestMatchers(HttpMethod.GET, "/application/v3/application/{applicantId}").hasAnyAuthority(
+                        Role.ADMIN.name()
                 )
                 .requestMatchers(HttpMethod.PUT, "/application/v3/application/{applicantId}").hasAnyAuthority(
                         Role.ADMIN.name(),
                         Role.ROOT.name()
                 )
                 .requestMatchers(HttpMethod.GET, "/application/v3/application/all").hasAnyAuthority(
-                        Role.ADMIN.name()
-                )
-                .requestMatchers(HttpMethod.GET, "/application/v3/application/{authenticationId}").hasAnyAuthority(
                         Role.ADMIN.name()
                 )
                 .requestMatchers(HttpMethod.PUT, "/application/v1/final-submit").hasAnyAuthority(


### PR DESCRIPTION
## 개요

원서 도메인(AbstractApplication)에 심층면접 점수(interviewScore) 추가 및 1, 2차 결과 객체 필드에 점수(score)필드를 추가하였습니다.

## 본문

- `AbstractApplication` 엔티티에 `interviewScore` 필드를 추가하였습니다.
- 기존에 누락되어있던 `EvaluationResult` 클래스의 `score` 필드를 추가하였습니다.
- 원서 조회, 전체조회 반환값에 `interviewScore` 필드를 추가하였습니다.
- 시큐리티 권한 매핑을 수정하였습니다.

## 기타
- 내 원서 조회, 원서 조회, 원서 전체 조회시 controller 메서드에서 `ResponseEntity`로 [감싸서 반환하는 부분을 제거하였습니다.](https://github.com/themoment-team/hellogsm-server-v3/pull/37)
